### PR TITLE
Add a `timestamp()` method (and verification)

### DIFF
--- a/lib/__tests__/client.test.js
+++ b/lib/__tests__/client.test.js
@@ -212,4 +212,12 @@ describe('Client', () => {
     let verify = await client.verify(signedData, config.publicSignKey)
     expect(verify).toBe(true)
   })
+
+  it('signs and returns a timestamp', async () => {
+    let client = new Client(config)
+    let timestamp = await client.timestamp()
+
+    let verify = await client.verifyTimestamp(timestamp, config.publicSignKey)
+    expect(verify).toBe(true)
+  })
 })

--- a/lib/__tests__/crypto.test.js
+++ b/lib/__tests__/crypto.test.js
@@ -72,4 +72,15 @@ describe('Crypto', () => {
 
     expect(verified).toBe(true)
   })
+
+  it('signs and verifies arbitrary documents with a given key', async () => {
+    await sodium.ready
+    let salt = sodium.randombytes_buf(16)
+    let keyPair = await Crypto.deriveSigningKey('thisisapassword', salt)
+
+    let signature = await Crypto.sign('testing1234', keyPair.privateKey)
+    let verified = await Crypto.verify('testing1234', signature, keyPair.publicKey)
+
+    expect(verified).toBe(true)
+  })
 })

--- a/lib/client.js
+++ b/lib/client.js
@@ -1004,6 +1004,41 @@ export default class Client {
   }
 
   /**
+   * Get the current Unix timestamp, signed with the client's private key.
+   *
+   * The timestamp returned will be in the format `timestamp.signature`, with the
+   * signature itself Base64url-encoded.
+   *
+   * @returns {Promise.<string>}
+   */
+  async timestamp() {
+    if (this.config.version === 1) {
+      throw new Error('Cannot create signatures without a signing key!')
+    }
+
+    let now = String(Math.floor(new Date() / 1000))
+    let signature = await Crypto.sign(now, this.config.privateSignKey)
+
+    return now + '.' + signature
+  }
+
+  /**
+   * Verify a signed Unix timestamp against a specific public key.
+   *
+   * @param {string} timestamp    Timestamp to verify (encoded as `timestamp.signature`)
+   * @param {string} verifyingKey Base64-url encoded public key used for signature verification
+   *
+   * @returns {Promise.<bool>}
+   */
+  async verifyTimestamp(timestamp, verifyingKey) {
+    let parts = timestamp.split('.')
+    let time = parts[0]
+    let signature = parts[1]
+
+    return Crypto.verify(time, signature, verifyingKey)
+  }
+
+  /**
    * Register a new client with a specific account.
    *
    * @param {string}  registrationToken Registration token as presented by the admin console

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -159,6 +159,24 @@ export default class Crypto {
   }
 
   /**
+   * Verify the signature on an arbitrary signed string, given a specific public signing key.
+   *
+   * @param {string} str          String to be erified
+   * @param {string} signature    Base64URL-encoded signature
+   * @param {string} verifyingKey Base64URL-encoded signing key
+   *
+   * @returns {Promise.<bool>}
+   */
+  static async verify(str, signature, verifyingKey) {
+    await sodium.ready
+
+    let rawSignature = await Crypto.b64decode(signature)
+    let rawKey = await Crypto.b64decode(verifyingKey)
+
+    return sodium.crypto_sign_verify_detached(rawSignature, str, rawKey)
+  }
+
+  /**
    * Verify the signature on a given JSON document, given a specific public signing key.
    *
    * @param {Serializable} document     Document to be verified
@@ -168,12 +186,25 @@ export default class Crypto {
    * @returns {Promise<bool>}
    */
   static async verifyDocumentSignature(document, signature, verifyingKey) {
-    await sodium.ready
     let message = document.stringify()
-    let rawSignature = await Crypto.b64decode(signature)
-    let rawKey = await Crypto.b64decode(verifyingKey)
+    return Crypto.verify(message, signature, verifyingKey)
+  }
 
-    return sodium.crypto_sign_verify_detached(rawSignature, message, rawKey)
+  /**
+   * Sign an arbitrary string of data with a specific key.
+   *
+   * @param {string} str        Data to sign
+   * @param {string} signingKey Key to use while signing the string
+   *
+   * @returns {Promise.<string>}
+   */
+  static async sign(str, signingKey) {
+    await sodium.ready
+
+    let rawKey = await Crypto.b64decode(signingKey)
+    let signature = sodium.crypto_sign_detached(str, rawKey)
+
+    return Crypto.b64encode(signature)
   }
 
   /**
@@ -185,13 +216,8 @@ export default class Crypto {
    * @returns {Promise<string>}
    */
   static async signDocument(document, signingKey) {
-    await sodium.ready
     let message = document.stringify()
-    let rawKey = await Crypto.b64decode(signingKey)
-
-    let signature = sodium.crypto_sign_detached(message, rawKey)
-
-    return Crypto.b64encode(signature)
+    return Crypto.sign(message, signingKey)
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -6021,7 +6021,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -6160,7 +6160,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -6932,7 +6932,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },


### PR DESCRIPTION
The `Client` object now exposes both a timestamp creation and
verification routine. The timestamp routine creates a Unix timestamp and
signs it with the client's private key.

The verification routine splits the generated timestamp from its linked
signature and verifies the signature against a specified public key.

These changes are made to support adding signatures to HTTP request
headers by generating a signed timestamp and verifying it with another
SDK. Other headers can be arbitrarily signed as well as the
functionality now exposes signatures and verification for arbitrary
strings.